### PR TITLE
#19051 - bugfix: missing thumbnails for a/v and a/v not loading

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
@@ -143,7 +143,7 @@
           "enabled": true,
           "paramType": "?"
         },
-        "thumbsEnabled": true,
+        "thumbsEnabled": false,
         "thumbsExtraHeight": 8,
         "thumbsImageFadeInDuration": 300,
         "thumbsLoadRange": 15,

--- a/src/iiif-collection.json
+++ b/src/iiif-collection.json
@@ -44,6 +44,11 @@
           "@id": "https://lbiiif-acc.riksarkivet.se/arkis!T0000013/manifest",
           "@type": "sc:Manifest",
           "label": "Big Buck Bunny (Video)"
+        },
+        {
+          "@id": "https://lbiiif-acc.riksarkivet.se/arkis!T0000235/manifest",
+          "@type": "sc:Manifest",
+          "label": "T0000235, en_daares_foersvarstal.mp3 (1 öppen ljudfil)"
         }
       ]
     },

--- a/src/uv-iiif-config.json
+++ b/src/uv-iiif-config.json
@@ -77,8 +77,7 @@
     },
     "contentLeftPanel": {
       "options": {
-        "defaultToTreeEnabled": true,
-        "thumbsEnabled": false
+        "defaultToTreeEnabled": false
       }
      },
       "searchFooterPanel" :{


### PR DESCRIPTION
Changed configuration settings values for 'defaultToTreeEnabled' and 'thumbsEnabled' options.