### PR TITLE
19217 - Fix for Uncaught (in promise) TypeError: HTMLMediaElement.currentTime setter

### DIFF
--- a/src/content-handlers/iiif/modules/uv-avcenterpanel-module/AVCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-avcenterpanel-module/AVCenterPanel.ts
@@ -48,11 +48,7 @@ export class AVCenterPanel extends CenterPanel<
       IIIFEvents.CANVAS_INDEX_CHANGE,
       (canvasIndex: number) => {
         if (this._lastCanvasIndex !== canvasIndex) {
-          let range = this.extension.getCurrentCanvasRange()
-          this.extensionHost.publish(IIIFEvents.RANGE_CHANGE, range);
-          this._whenMediaReady(() => {
-            this._viewCanvas(canvasIndex);
-          });
+          this._viewCanvas(canvasIndex);
         }
       }
     );


### PR DESCRIPTION
Fix for Uncaught (in promise) TypeError: HTMLMediaElement.currentTime setter: Value being assigned is not a finite floating-point value.